### PR TITLE
BenchmarkExpirationOverhead_N function to measure it.

### DIFF
--- a/timewheel_kvbench_test.go
+++ b/timewheel_kvbench_test.go
@@ -129,6 +129,8 @@ func BenchmarkExpirationOverhead_N(b *testing.B) {
 				b.StartTimer()
 				start := time.Now()
 
+				time.Sleep(50 * time.Millisecond)
+
 				totalExpired := 0
 				tickCount := 0
 				for totalExpired < n {
@@ -161,6 +163,7 @@ func BenchmarkExpirationOverhead_N(b *testing.B) {
 
 				start := time.Now()
 
+				// this is very similar we are not making any map here as of now.
 				for j := 0; j < n; j++ {
 					time.AfterFunc(50*time.Millisecond, func() {
 						atomic.AddInt64(&expiredCount, 1)

--- a/timewheel_kvbench_test.go
+++ b/timewheel_kvbench_test.go
@@ -1,0 +1,183 @@
+package taskwheel
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type SimpleTimingWheelCache struct {
+	wheel *TimingWheel[string]
+	mu    sync.RWMutex
+	data  map[string]string
+}
+
+func NewSimpleTimingWheelCache(tickInterval time.Duration, slots int) *SimpleTimingWheelCache {
+	return &SimpleTimingWheelCache{
+		wheel: NewTimingWheel[string](tickInterval, slots, 0),
+		data:  make(map[string]string),
+	}
+}
+
+func (c *SimpleTimingWheelCache) Set(key, value string, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = value
+	_, _ = c.wheel.AfterTimeout(TimerID(key), value, ttl)
+}
+
+func (c *SimpleTimingWheelCache) Get(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	value, ok := c.data[key]
+	return value, ok
+}
+
+func (c *SimpleTimingWheelCache) ManualTick() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	expired := c.wheel.Tick()
+	for _, timer := range expired {
+		delete(c.data, string(timer.ID))
+	}
+	return len(expired)
+}
+
+func (c *SimpleTimingWheelCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.data)
+}
+
+type NativeTimerCache struct {
+	mu     sync.RWMutex
+	data   map[string]string
+	timers map[string]*time.Timer
+}
+
+func NewNativeTimerCache() *NativeTimerCache {
+	return &NativeTimerCache{
+		data:   make(map[string]string),
+		timers: make(map[string]*time.Timer),
+	}
+}
+
+func (c *NativeTimerCache) Set(key, value string, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if timer, exists := c.timers[key]; exists {
+		timer.Stop()
+	}
+
+	c.data[key] = value
+	c.timers[key] = time.AfterFunc(ttl, func() {
+		c.mu.Lock()
+		delete(c.data, key)
+		delete(c.timers, key)
+		c.mu.Unlock()
+	})
+}
+
+func (c *NativeTimerCache) Get(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	value, ok := c.data[key]
+	return value, ok
+}
+
+func (c *NativeTimerCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if timer, exists := c.timers[key]; exists {
+		timer.Stop()
+		delete(c.timers, key)
+	}
+	delete(c.data, key)
+}
+
+func (c *NativeTimerCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.data)
+}
+
+func BenchmarkExpirationOverhead_N(b *testing.B) {
+	numKeys := []int{1_000, 10_000, 100_000}
+
+	for _, n := range numKeys {
+		b.Run(fmt.Sprintf("TimingWheel_Expiration_%d", n), func(b *testing.B) {
+
+			keys := make([]string, n)
+			for i := 0; i < n; i++ {
+				keys[i] = fmt.Sprintf("key-%d", i)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				cache := NewSimpleTimingWheelCache(1*time.Millisecond, 10000)
+
+				for j := 0; j < n; j++ {
+					cache.Set(keys[j], "value", 50*time.Millisecond)
+				}
+
+				b.StartTimer()
+				start := time.Now()
+
+				totalExpired := 0
+				tickCount := 0
+				for totalExpired < n {
+					expired := cache.ManualTick()
+					totalExpired += expired
+					tickCount++
+
+					if tickCount > 10000 {
+						b.Fatalf("Too many ticks, possible infinite loop")
+					}
+				}
+
+				duration := time.Since(start)
+
+				if i == 0 {
+					b.Logf("Expired %d timers in %v (%.2f ns/timer, %d ticks)",
+						n, duration, float64(duration.Nanoseconds())/float64(n), tickCount)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("NativeTimer_Expiration_%d", n), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				var expiredCount int64
+				var wg sync.WaitGroup
+				wg.Add(n)
+
+				start := time.Now()
+
+				for j := 0; j < n; j++ {
+					time.AfterFunc(50*time.Millisecond, func() {
+						atomic.AddInt64(&expiredCount, 1)
+						wg.Done()
+					})
+				}
+
+				wg.Wait()
+
+				duration := time.Since(start)
+				expired := atomic.LoadInt64(&expiredCount)
+
+				if i == 0 {
+					b.Logf("Expired %d timers in %v (%.2f ns/timer)",
+						expired, duration, float64(duration.Nanoseconds())/float64(expired))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/ankur-anand/taskwheel
cpu: Apple M2 Pro
BenchmarkExpirationOverhead_N
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_1000
    timewheel_kvbench_test.go:149: Expired 1000 timers in 51.16775ms (51167.75 ns/timer, 50 ticks)
    timewheel_kvbench_test.go:149: Expired 1000 timers in 51.1615ms (51161.50 ns/timer, 50 ticks)
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_1000-10         	      22	  51217729 ns/op	   17599 B/op	      11 allocs/op
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_1000
    timewheel_kvbench_test.go:180: Expired 1000 timers in 53.3345ms (53334.50 ns/timer)
    timewheel_kvbench_test.go:180: Expired 1000 timers in 51.043667ms (51043.67 ns/timer)
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_1000-10         	      21	  52520448 ns/op	  160767 B/op	    2030 allocs/op
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_10000
    timewheel_kvbench_test.go:149: Expired 10000 timers in 53.446667ms (5344.67 ns/timer, 50 ticks)
    timewheel_kvbench_test.go:149: Expired 10000 timers in 53.252ms (5325.20 ns/timer, 50 ticks)
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_10000-10        	      21	  54239887 ns/op	  310541 B/op	      19 allocs/op
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_10000
    timewheel_kvbench_test.go:180: Expired 10000 timers in 65.527292ms (6552.73 ns/timer)
    timewheel_kvbench_test.go:180: Expired 10000 timers in 59.583583ms (5958.36 ns/timer)
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_10000-10        	      18	  60911421 ns/op	 1642391 B/op	   20151 allocs/op
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_100000
    timewheel_kvbench_test.go:149: Expired 100000 timers in 63.087833ms (630.88 ns/timer, 50 ticks)
    timewheel_kvbench_test.go:149: Expired 100000 timers in 61.423583ms (614.24 ns/timer, 50 ticks)
BenchmarkExpirationOverhead_N/TimingWheel_Expiration_100000-10       	      18	  61491208 ns/op	 4496669 B/op	      29 allocs/op
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_100000
    timewheel_kvbench_test.go:180: Expired 100000 timers in 112.584875ms (1125.85 ns/timer)
    timewheel_kvbench_test.go:180: Expired 100000 timers in 84.482333ms (844.82 ns/timer)
    timewheel_kvbench_test.go:180: Expired 100000 timers in 104.541958ms (1045.42 ns/timer)
BenchmarkExpirationOverhead_N/NativeTimer_Expiration_100000-10       	      12	  98369708 ns/op	16182727 B/op	  200580 allocs/op
PASS

```