### PR TITLE
memory optimization for each task

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A high-performance, generic **Hierarchical Timing Wheel** implementation in Go for efficient timer management at scale.
 
+## Why TaskWheel?
+
+When you need to manage thousands or millions or timers (timeouts, TTLs, scheduled tasks) etc. While Go's standard `time.Timer` is excellent, it faces some challenges at high volumes.
+
 ### Installation
 
 ```bash
@@ -114,27 +118,38 @@ goos: darwin
 goarch: arm64
 pkg: github.com/ankur-anand/taskwheel
 cpu: Apple M2 Pro
-BenchmarkNativeTimers/1K_timers_100ms-10         	      10	 102039642 ns/op	  191393 B/op	    2091 allocs/op
-BenchmarkNativeTimers/10K_timers_100ms-10        	       9	 114114778 ns/op	 1820984 B/op	   20260 allocs/op
-BenchmarkNativeTimers/100K_timers_1s-10          	       1	1090769709 ns/op	39694704 B/op	  240698 allocs/op
-BenchmarkTimingWheelAfterTimeout/1K_timers_100ms-10         	      10	 110101579 ns/op	  315608 B/op	    1056 allocs/op
-BenchmarkTimingWheelAfterTimeout/10K_timers_100ms-10        	       9	 111119176 ns/op	 2857496 B/op	   10181 allocs/op
-BenchmarkTimingWheelAfterTimeout/100K_timers_100ms-10       	       9	 122693727 ns/op	26476164 B/op	  101094 allocs/op
-BenchmarkMemoryComparison/Native_10K_timers-10              	      10	 111232592 ns/op	 1429328 B/op	   20003 allocs/op
-BenchmarkMemoryComparison/TimingWheel_10K_timers-10         	      10	 110203346 ns/op	 2857505 B/op	   10181 allocs/op
+BenchmarkNativeTimers/1K_timers_100ms-10                             	      10	 102317362 ns/op	  136000 B/op	    2000 allocs/op
+BenchmarkNativeTimers/10K_timers_100ms-10                            	      10	 113182400 ns/op	 1360000 B/op	   20000 allocs/op
+BenchmarkNativeTimers/100K_timers_1s-10                              	       1	1093996708 ns/op	13600000 B/op	  200000 allocs/op
+BenchmarkTimingWheelAfterTimeout/1K_timers_100ms-10                  	      10	 110006242 ns/op	  214488 B/op	    1056 allocs/op
+BenchmarkTimingWheelAfterTimeout/10K_timers_100ms-10                 	      10	 110001250 ns/op	 1973784 B/op	   10181 allocs/op
+BenchmarkTimingWheelAfterTimeout/100K_timers_100ms-10                	       9	 121230764 ns/op	18755629 B/op	  101093 allocs/op
+BenchmarkMemoryComparison/Native_10K_timers-10                       	      10	 111245146 ns/op	 1336540 B/op	   20001 allocs/op
+BenchmarkMemoryComparison/TimingWheel_10K_timers-10                  	      10	 109956992 ns/op	 1973784 B/op	   10181 allocs/op
+BenchmarkTimingWheel_Memory/Timers_100000-10                         	      67	  19544636 ns/op	 9665561 B/op	  600001 allocs/op
+BenchmarkTimingWheel_Memory/Timers_1000000-10                        	       6	 199790202 ns/op	96065897 B/op	 6000003 allocs/op
+BenchmarkTimingWheel_Memory/Timers_10000000-10                       	       1	1807187459 ns/op	960067416 B/op	60000009 allocs/op
+BenchmarkNativeTimer_Memory/Timers_100000-10                         	     140	  12572099 ns/op	15329470 B/op	  100001 allocs/op
+BenchmarkNativeTimer_Memory/Timers_1000000-10                        	      13	 145825920 ns/op	151103566 B/op	 1000001 allocs/op
+BenchmarkNativeTimer_Memory/Timers_10000000-10                       	       1	1309542667 ns/op	1705383936 B/op	10000002 allocs/op
 ```
+### Performance Comparison
 
 | Workload              | Metric     | NativeTimers | TimingWheel | Difference |
 |-----------------------|------------|--------------|-------------|------------|
 | **1K timers (100ms)** | Time/op    | 102 ms       | 110 ms      | +8% slower |
-|                       | Mem/op     | 191 KB       | 316 KB      | +65% more  |
-|                       | Allocs/op  | 2.1 K        | 1.1 K       | -50% fewer |
-| **10K timers (100ms)**| Time/op    | 114 ms       | 111 ms      | -3% faster |
-|                       | Mem/op     | 1.8 MB       | 2.9 MB      | +57% more  |
-|                       | Allocs/op  | 20.3 K       | 10.2 K      | -50% fewer |
+|                       | Mem/op     | 136 KB       | 214 KB      | +58% more  |
+|                       | Allocs/op  | 2.0 K        | 1.1 K       | -47% fewer |
+| **10K timers (100ms)**| Time/op    | 113 ms       | 110 ms      | -3% faster |
+|                       | Mem/op     | 1.36 MB      | 1.97 MB     | +45% more  |
+|                       | Allocs/op  | 20.0 K       | 10.2 K      | -49% fewer |
 | **100K timers (1s)**  | Time/op    | 1.09 s       | 0.12 s      | -89% faster |
-|                       | Mem/op     | 39.7 MB      | 26.5 MB     | -33% less  |
-|                       | Allocs/op  | 240.7 K      | 101.1 K     | -58% fewer |
+|                       | Mem/op     | 13.6 MB      | 18.8 MB     | +38% more  |
+|                       | Allocs/op  | 200.0 K      | 101.1 K     | -50% fewer |
+
+**At very small scales (≈1K timers)**, TimingWheel shows a slight overhead (+8% slower, more memory).  
+But once you reach **10K+ timers**, it matches or beats native performance, consistently cuts allocations ~50%,
+and at **100K timers** it’s ~9× faster with half the allocations.
 
 ## Advanced Usage
 

--- a/hierarchical_timewheel.go
+++ b/hierarchical_timewheel.go
@@ -18,9 +18,18 @@ type HierarchicalTimingWheel[T any] struct {
 }
 
 // NewHierarchicalTimingWheel returns an initialized Active State Wheel.
+// Maximum of 255 levels and 65535 slots per level are supported.
 func NewHierarchicalTimingWheel[T any](intervals []time.Duration, slots []int) *HierarchicalTimingWheel[T] {
 	if len(intervals) != len(slots) {
 		panic("intervals and slots length mismatch")
+	}
+
+	if len(intervals) == 0 {
+		panic("intervals must not be empty")
+	}
+
+	if len(intervals) > 255 {
+		panic("intervals must not be more than 255 elements")
 	}
 
 	var maxSpans []time.Duration
@@ -33,6 +42,9 @@ func NewHierarchicalTimingWheel[T any](intervals []time.Duration, slots []int) *
 		}
 		if slots[i] <= 0 {
 			panic(fmt.Sprintf("slots[%d] must be > 0", i))
+		}
+		if slots[i] > 65535 {
+			panic(fmt.Sprintf("slots[%d] must be <= 65535", i))
 		}
 		levels[i] = NewTimingWheel[T](intervals[i], slots[i], i)
 		span := time.Duration(slots[i]) * intervals[i]
@@ -65,8 +77,8 @@ func (htw *HierarchicalTimingWheel[T]) AfterTimeout(id TimerID, value T, timeout
 		ID:      id,
 		Value:   value,
 		NextDue: due,
-		slot:    slot,
-		level:   level,
+		slot:    uint16(slot),
+		level:   uint8(level),
 	}
 
 	tw := htw.levels[level]
@@ -142,9 +154,10 @@ func (htw *HierarchicalTimingWheel[T]) Tick() []*Timer[T] {
 				due = append(due, t)
 			} else {
 				// down to the right slot of the next lower level.
-				remaining := time.Until(t.NextDue)
+				nextDue := time.Unix(0, t.NextDue)
+				remaining := time.Until(nextDue)
 				level, slot, _ := htw.calcPlacement(remaining, time.Now())
-				t.level, t.slot = level, slot
+				t.level, t.slot = uint8(level), uint16(slot)
 				htw.levels[level].slots[slot].push(t)
 				htw.levels[level].timerMap[t.ID] = t
 			}
@@ -155,7 +168,7 @@ func (htw *HierarchicalTimingWheel[T]) Tick() []*Timer[T] {
 	return due
 }
 
-func (htw *HierarchicalTimingWheel[T]) calcPlacement(timeout time.Duration, now time.Time) (level, slot int, due time.Time) {
+func (htw *HierarchicalTimingWheel[T]) calcPlacement(timeout time.Duration, now time.Time) (level, slot int, due int64) {
 	for lvl, tw := range htw.levels {
 		levelSpan := time.Duration(tw.numSlots) * tw.interval
 		if timeout < levelSpan || lvl == htw.numLevels-1 {
@@ -164,7 +177,7 @@ func (htw *HierarchicalTimingWheel[T]) calcPlacement(timeout time.Duration, now 
 				delayInTicks = 1
 			}
 			slot = (tw.currentSlot + delayInTicks) % tw.numSlots
-			due = now.Add(timeout)
+			due = now.Add(timeout).UnixNano()
 			return lvl, slot, due
 		}
 		timeout -= levelSpan

--- a/hierarchical_timewheel_test.go
+++ b/hierarchical_timewheel_test.go
@@ -18,8 +18,8 @@ func ExampleHierarchicalTimingWheel() {
 	})
 	defer stop()
 
-	_, _ = wheel.AfterTimeout("a", "short", 45*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "long", 2*time.Second)
+	_, _ = wheel.AfterTimeout(HashID("a"), "short", 45*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "long", 2*time.Second)
 
 	time.Sleep(3 * time.Second)
 	// Output:
@@ -47,8 +47,8 @@ func ExampleHierarchicalTimingWheel_StartBatch() {
 
 	defer stop()
 
-	_, _ = wheel.AfterTimeout("a", "short", 45*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "long", 50*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "short", 45*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "long", 50*time.Millisecond)
 	time.Sleep(3 * time.Second)
 	// Output:
 	// Batch of 2 timers fired
@@ -76,17 +76,17 @@ func TestHierarchicalTimingWheel_FiresTimersCorrectly(t *testing.T) {
 	})
 	defer stop()
 
-	_, err := wheel.AfterTimeout("a", "fire50ms", 50*time.Millisecond)
+	_, err := wheel.AfterTimeout(HashID("a"), "fire50ms", 50*time.Millisecond)
 	if err != nil {
 		t.Fatalf("AfterTimeout failed: %v", err)
 	}
 
-	_, err = wheel.AfterTimeout("b", "fire1.3s", 1300*time.Millisecond)
+	_, err = wheel.AfterTimeout(HashID("b"), "fire1.3s", 1300*time.Millisecond)
 	if err != nil {
 		t.Fatalf("AfterTimeout failed: %v", err)
 	}
 
-	_, err = wheel.AfterTimeout("c", "fire2s", 2*time.Second)
+	_, err = wheel.AfterTimeout(HashID("c"), "fire2s", 2*time.Second)
 	if err != nil {
 		t.Fatalf("AfterTimeout failed: %v", err)
 	}
@@ -135,16 +135,16 @@ func TestHierarchicalTimingWheel_Remove(t *testing.T) {
 	})
 	defer stop()
 
-	_, err := wheel.AfterTimeout("a", "should_fire", 30*time.Millisecond)
+	_, err := wheel.AfterTimeout(HashID("a"), "should_fire", 30*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = wheel.AfterTimeout("b", "should_NOT_fire", 200*time.Millisecond)
+	_, err = wheel.AfterTimeout(HashID("b"), "should_NOT_fire", 200*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ok := wheel.Remove("b")
+	ok := wheel.Remove(HashID("b"))
 	if !ok {
 		t.Fatal("Remove failed for timer b")
 	}
@@ -172,14 +172,14 @@ func TestHierarchicalTimingWheel_OrderAndPrecision(t *testing.T) {
 	start := time.Now()
 	stop := wheel.Start(10*time.Millisecond, func(timer *Timer[string]) {
 		mu.Lock()
-		fireTimes[string(timer.ID)] = time.Now()
+		fireTimes[timer.Value] = time.Now()
 		mu.Unlock()
 		wg.Done()
 	})
 	defer stop()
 
-	_, _ = wheel.AfterTimeout("a", "t1", 80*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "t2", 160*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "a", 80*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "b", 160*time.Millisecond)
 
 	wg.Wait()
 
@@ -210,7 +210,7 @@ func TestHierarchicalTimingWheel_Pause_And_Resume(t *testing.T) {
 	})
 	defer stop()
 
-	_, err := wheel.AfterTimeout("a", "should_fire_after_resume", 100*time.Millisecond)
+	_, err := wheel.AfterTimeout(HashID("a"), "should_fire_after_resume", 100*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,9 +258,9 @@ func TestHierarchicalTimingWheel_Drain(t *testing.T) {
 	slots := []int{100, 60}
 	wheel := NewHierarchicalTimingWheel[string](intervals, slots)
 
-	_, _ = wheel.AfterTimeout("a", "A", 50*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "B", 1*time.Second)
-	_, _ = wheel.AfterTimeout("c", "C", 1*time.Second+100*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "A", 50*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "B", 1*time.Second)
+	_, _ = wheel.AfterTimeout(HashID("c"), "C", 1*time.Second+100*time.Millisecond)
 
 	drained := wheel.Drain()
 	found := map[string]bool{"A": false, "B": false, "C": false}
@@ -286,9 +286,9 @@ func TestHierarchicalTimingWheel_Reset(t *testing.T) {
 	slots := []int{100, 60}
 	wheel := NewHierarchicalTimingWheel[string](intervals, slots)
 
-	_, _ = wheel.AfterTimeout("a", "A", 50*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "B", 1*time.Second)
-	_, _ = wheel.AfterTimeout("c", "C", 1*time.Second+100*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "A", 50*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "B", 1*time.Second)
+	_, _ = wheel.AfterTimeout(HashID("c"), "C", 1*time.Second+100*time.Millisecond)
 
 	wheel.Reset()
 	if got := wheel.Len(); got != 0 {
@@ -307,14 +307,14 @@ func TestHierarchicalTimingWheel_Get(t *testing.T) {
 	slots := []int{100, 60}
 	wheel := NewHierarchicalTimingWheel[string](intervals, slots)
 
-	_, ok := wheel.Get("nonexistent")
+	_, ok := wheel.Get(HashID("nonexistent"))
 	if ok {
 		t.Fatal("Expected Get to return false for missing timer")
 	}
 
-	_, _ = wheel.AfterTimeout("xid", "payload", 200*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("xid"), "payload", 200*time.Millisecond)
 
-	tmr, ok := wheel.Get("xid")
+	tmr, ok := wheel.Get(HashID("xid"))
 	if !ok || tmr.Value != "payload" {
 		t.Fatal("Get did not find the expected timer")
 	}
@@ -329,14 +329,14 @@ func TestHierarchicalTimingWheel_Len(t *testing.T) {
 		t.Fatalf("Expected 0 timers at start")
 	}
 
-	_, _ = wheel.AfterTimeout("a", "A", 30*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "B", 70*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "A", 30*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "B", 70*time.Millisecond)
 
 	if wheel.Len() != 2 {
 		t.Fatalf("Expected 2 timers after insertions")
 	}
 
-	wheel.Remove("a")
+	wheel.Remove(HashID("a"))
 	if wheel.Len() != 1 {
 		t.Fatalf("Expected 1 timer after remove")
 	}
@@ -366,9 +366,9 @@ func TestHierarchicalTimingWheel_StartBatch(t *testing.T) {
 	})
 
 	defer stop()
-	_, _ = wheel.AfterTimeout("a", "A", 48*time.Millisecond)
-	_, _ = wheel.AfterTimeout("b", "B", 45*time.Millisecond)
-	_, _ = wheel.AfterTimeout("c", "C", 100*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("a"), "A", 48*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("b"), "B", 45*time.Millisecond)
+	_, _ = wheel.AfterTimeout(HashID("c"), "C", 100*time.Millisecond)
 
 	time.Sleep(300 * time.Millisecond)
 

--- a/timewheel.go
+++ b/timewheel.go
@@ -3,6 +3,7 @@ package taskwheel
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"time"
 )
 
@@ -14,20 +15,30 @@ const (
 )
 
 // TimerID is a uniqueID associated with each Timer Instance.
-type TimerID string
+type TimerID uint64
+
+// HashID converts a string to a TimerID using FNV-1a hash.
+func HashID(s string) TimerID {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return TimerID(h.Sum64())
+}
 
 // Timer is scheduled event managed by a Timing Wheel.
 // It's support generic payload type [T].
 type Timer[T any] struct {
-	ID    TimerID
-	Value T
+	ID TimerID
 	// NextDue is the wall clock when this timer should be fired.
-	NextDue time.Time
+	NextDue int64
+
+	Value T
 
 	prev, next *Timer[T]
 	// Index of the slot ()
-	slot  int
-	level int
+	slot  uint16
+	level uint8
+	// 1 byte pad
+	_ uint8
 }
 
 type slotList[T any] struct {
@@ -75,7 +86,6 @@ type TimingWheel[T any] struct {
 	numSlots    int
 	slots       []slotList[T]
 	currentSlot int
-	ticker      *time.Ticker
 
 	timerMap map[TimerID]*Timer[T]
 	level    int
@@ -125,8 +135,9 @@ func (tw *TimingWheel[T]) add(id TimerID, value T, timeout time.Duration) (*Time
 	timer := &Timer[T]{
 		ID:      id,
 		Value:   value,
-		NextDue: now.Add(timeout),
-		slot:    slot,
+		NextDue: now.Add(timeout).UnixNano(),
+		slot:    uint16(slot),
+		level:   0,
 	}
 	tw.slots[slot].push(timer)
 	tw.timerMap[id] = timer

--- a/timewheel_bench_test.go
+++ b/timewheel_bench_test.go
@@ -3,7 +3,6 @@ package taskwheel_test
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -90,7 +89,7 @@ func BenchmarkTimingWheelPeriodic(b *testing.B) {
 		tw := taskwheel.NewTimingWheel[string](interval, 200, 0)
 
 		for j := 0; j < numTimers; j++ {
-			id := taskwheel.TimerID(strconv.Itoa(j))
+			id := taskwheel.TimerID(rune(j))
 			_, _ = tw.AfterTimeout(id, "payload", baseTickerInterval)
 		}
 

--- a/timewheel_kvbench_test.go
+++ b/timewheel_kvbench_test.go
@@ -25,7 +25,7 @@ func (c *SimpleTimingWheelCache) Set(key, value string, ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.data[key] = value
-	_, _ = c.wheel.AfterTimeout(TimerID(key), value, ttl)
+	_, _ = c.wheel.AfterTimeout(HashID(key), key, ttl)
 }
 
 func (c *SimpleTimingWheelCache) Get(key string) (string, bool) {
@@ -40,7 +40,7 @@ func (c *SimpleTimingWheelCache) ManualTick() int {
 	defer c.mu.Unlock()
 	expired := c.wheel.Tick()
 	for _, timer := range expired {
-		delete(c.data, string(timer.ID))
+		delete(c.data, timer.Value)
 	}
 	return len(expired)
 }

--- a/timewheel_test.go
+++ b/timewheel_test.go
@@ -16,7 +16,7 @@ func TestTimingWheel_AfterTimeout_And_Tick(t *testing.T) {
 	var mu sync.Mutex
 	var fired []string
 
-	id := taskwheel.TimerID("42")
+	id := taskwheel.HashID("42")
 	value := "hello world"
 
 	_, err := tw.AfterTimeout(id, value, 50*time.Millisecond)
@@ -52,7 +52,7 @@ func TestTimingWheel_AfterTimeout_Errors(t *testing.T) {
 	numSlots := 100
 	tw := taskwheel.NewTimingWheel[string](interval, numSlots, 0)
 
-	id := taskwheel.TimerID("error")
+	id := taskwheel.HashID("error")
 
 	if _, err := tw.AfterTimeout(id, "bad", 0); err == nil {
 		t.Error("expected error for zero timeout, got nil")
@@ -77,7 +77,7 @@ func TestTimingWheel_DuplicateID_ReplacesOldTimer(t *testing.T) {
 	numSlots := 100
 	tw := taskwheel.NewTimingWheel[string](interval, numSlots, 0)
 
-	id := taskwheel.TimerID("dup")
+	id := taskwheel.HashID("dup")
 
 	_, err := tw.AfterTimeout(id, "first", 30*time.Millisecond)
 	if err != nil {
@@ -112,7 +112,7 @@ func TestTimingWheel_Remove_RemovesTimer(t *testing.T) {
 	interval := 10 * time.Millisecond
 	numSlots := 100
 	tw := taskwheel.NewTimingWheel[string](interval, numSlots, 0)
-	id := taskwheel.TimerID("remove-me")
+	id := taskwheel.HashID("remove-me")
 
 	_, err := tw.AfterTimeout(id, "bye", 50*time.Millisecond)
 	if err != nil {
@@ -145,11 +145,11 @@ func TestTimingWheel_Len(t *testing.T) {
 		t.Fatalf("expected Len() == 0, got %d", got)
 	}
 
-	_, err := tw.AfterTimeout("foo", "val1", 20*time.Millisecond)
+	_, err := tw.AfterTimeout(taskwheel.HashID("foo"), "val1", 20*time.Millisecond)
 	if err != nil {
 		t.Fatalf("AfterTimeout error: %v", err)
 	}
-	_, err = tw.AfterTimeout("bar", "val2", 30*time.Millisecond)
+	_, err = tw.AfterTimeout(taskwheel.HashID("bar"), "val2", 30*time.Millisecond)
 	if err != nil {
 		t.Fatalf("AfterTimeout error: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestTimingWheel_Len(t *testing.T) {
 		t.Fatalf("expected Len() == 2, got %d", got)
 	}
 
-	tw.Remove("foo")
+	tw.Remove(taskwheel.HashID("foo"))
 	if got := tw.Len(); got != 1 {
 		t.Fatalf("expected Len() == 1 after remove, got %d", got)
 	}
@@ -169,7 +169,7 @@ func TestTimingWheel_Get(t *testing.T) {
 	numSlots := 100
 	tw := taskwheel.NewTimingWheel[string](interval, numSlots, 0)
 
-	id := taskwheel.TimerID("unique-id")
+	id := taskwheel.HashID("unique-id")
 	val := "payload"
 
 	if _, ok := tw.Get(id); ok {
@@ -197,8 +197,8 @@ func TestTimingWheel_Get(t *testing.T) {
 
 func TestTimingWheel_Reset(t *testing.T) {
 	tw := taskwheel.NewTimingWheel[string](10*time.Millisecond, 10, 0)
-	_, _ = tw.AfterTimeout("a", "A", 10*time.Millisecond)
-	_, _ = tw.AfterTimeout("b", "B", 20*time.Millisecond)
+	_, _ = tw.AfterTimeout(taskwheel.HashID("a"), "A", 10*time.Millisecond)
+	_, _ = tw.AfterTimeout(taskwheel.HashID("b"), "B", 20*time.Millisecond)
 
 	tw.Reset()
 	if tw.Len() != 0 {
@@ -213,7 +213,7 @@ func TestTimingWheel_Tick_PausedState(t *testing.T) {
 
 	tw.Pause()
 
-	id := taskwheel.TimerID("paused-id")
+	id := taskwheel.HashID("paused-id")
 	val := "do-not-fire"
 
 	_, err := tw.AfterTimeout(id, val, interval)
@@ -246,7 +246,7 @@ func TestTimingWheel_Tick_ActiveState(t *testing.T) {
 	numSlots := 10
 	tw := taskwheel.NewTimingWheel[string](interval, numSlots, 0)
 
-	id := taskwheel.TimerID("active-id")
+	id := taskwheel.HashID("active-id")
 	val := "should-fire"
 
 	_, err := tw.AfterTimeout(id, val, interval)

--- a/z_bench_test.go
+++ b/z_bench_test.go
@@ -82,7 +82,7 @@ func BenchmarkTimingWheelAfterTimeout(b *testing.B) {
 
 			ids := make([]TimerID, scenario.numTimers)
 			for j := 0; j < scenario.numTimers; j++ {
-				ids[j] = TimerID(fmt.Sprintf("timer-%d", j))
+				ids[j] = HashID(fmt.Sprintf("timer-%d", j))
 			}
 
 			b.ResetTimer()
@@ -148,7 +148,7 @@ func BenchmarkMemoryComparison(b *testing.B) {
 
 		ids := make([]TimerID, 10000)
 		for j := 0; j < 10000; j++ {
-			ids[j] = TimerID(fmt.Sprintf("timer-%d", j))
+			ids[j] = HashID(fmt.Sprintf("timer-%d", j))
 		}
 
 		b.ResetTimer()


### PR DESCRIPTION
This PR improve the memory usage across the board for the taskwheel timer.
```
benchstat old.txt new.txt | grep TimingWheel
TimingWheelAfterTimeout/1K_timers_100ms-10              110.1m ± ∞ ¹     110.0m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/10K_timers_100ms-10             111.1m ± ∞ ¹     110.0m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/100K_timers_100ms-10            122.7m ± ∞ ¹     121.2m ± ∞ ¹       ~ (p=1.000 n=1) ²
MemoryComparison/TimingWheel_10K_timers-10              110.2m ± ∞ ¹     110.0m ± ∞ ¹       ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_1000-10     51.26m ± ∞ ¹     51.14m ± ∞ ¹       ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_10000-10    54.12m ± ∞ ¹     53.48m ± ∞ ¹       ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_100000-10   61.03m ± ∞ ¹     59.90m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_AddRemove-10                                9.341n ± ∞ ¹   110.700n ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_FireBatch-10                                6.682n ± ∞ ¹     4.984n ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_100000-10                     24.43m ± ∞ ¹     19.54m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_1000000-10                    255.6m ± ∞ ¹     199.8m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_10000000-10                    2.718 ± ∞ ¹      1.807 ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheelPeriodic-10                                  212.8m ± ∞ ¹     206.1m ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/1K_timers_100ms-10              308.2Ki ± ∞ ¹   209.5Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/10K_timers_100ms-10             2.725Mi ± ∞ ¹   1.882Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/100K_timers_100ms-10            25.25Mi ± ∞ ¹   17.89Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
MemoryComparison/TimingWheel_10K_timers-10              2.725Mi ± ∞ ¹   1.882Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_1000-10     17.19Ki ± ∞ ¹   17.19Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
ExpirationOverhead_N/TimingWheel_Expiration_10000-10    303.2Ki ± ∞ ¹   303.3Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_100000-10   4.288Mi ± ∞ ¹   4.288Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheel_AddRemove-10                                  0.000 ± ∞ ¹     0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
TimingWheel_FireBatch-10                                  0.000 ± ∞ ¹     0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
TimingWheel_Memory/Timers_100000-10                     9.218Mi ± ∞ ¹   9.218Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_1000000-10                    91.62Mi ± ∞ ¹   91.62Mi ± ∞ ¹        ~ (p=1.000 n=1) ³
TimingWheel_Memory/Timers_10000000-10                   915.6Mi ± ∞ ¹   915.6Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheelPeriodic-10                                  60.45Mi ± ∞ ¹   46.30Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
TimingWheelAfterTimeout/1K_timers_100ms-10              1.056k ± ∞ ¹   1.056k ± ∞ ¹       ~ (p=1.000 n=1) ³
TimingWheelAfterTimeout/10K_timers_100ms-10             10.18k ± ∞ ¹   10.18k ± ∞ ¹       ~ (p=1.000 n=1) ³
TimingWheelAfterTimeout/100K_timers_100ms-10            101.1k ± ∞ ¹   101.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
MemoryComparison/TimingWheel_10K_timers-10              10.18k ± ∞ ¹   10.18k ± ∞ ¹       ~ (p=1.000 n=1) ³
ExpirationOverhead_N/TimingWheel_Expiration_1000-10      11.00 ± ∞ ¹    11.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
ExpirationOverhead_N/TimingWheel_Expiration_10000-10     18.00 ± ∞ ¹    19.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
ExpirationOverhead_N/TimingWheel_Expiration_100000-10    28.00 ± ∞ ¹    29.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_AddRemove-10                                 0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
TimingWheel_FireBatch-10                                 0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
TimingWheel_Memory/Timers_100000-10                     700.0k ± ∞ ¹   600.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_1000000-10                    7.000M ± ∞ ¹   6.000M ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheel_Memory/Timers_10000000-10                   70.00M ± ∞ ¹   60.00M ± ∞ ¹       ~ (p=1.000 n=1) ²
TimingWheelPeriodic-10                                  481.0k ± ∞ ¹   401.1k ± ∞ ¹       ~ (p=1.000 n=1)
```